### PR TITLE
Enable to configure contextName through data attributes

### DIFF
--- a/dist/javascript/jquery.selectpicker.js
+++ b/dist/javascript/jquery.selectpicker.js
@@ -131,7 +131,7 @@ jQuery.extend(
   jQuery.selectpicker.config,
   {
     contextName: function( context ) {
-      return context.prop( "name" );
+      return context.data().selectpickerName || context.prop( "name" );
     },
     items: function( context, options ) {
       var name = jQuery.selectpicker.config.contextName( context ),

--- a/src/javascript/config.js
+++ b/src/javascript/config.js
@@ -29,7 +29,7 @@ jQuery.extend(
   jQuery.selectpicker.config,
   {
     contextName: function( context ) {
-      return context.prop( "name" );
+      return context.data().selectpickerName || context.prop( "name" );
     },
     items: function( context, options ) {
       var name = jQuery.selectpicker.config.contextName( context ),


### PR DESCRIPTION
issue: #7 

`name` attribute of `select` elements may be duplicated but `jQuery.fn.selectpicker()` does not work well in this situation.

To resolve this problem, I enabled to configure `contextName` through data attributes. Please check this PR whenever you can.

To check this change, you can rewrite `index.html` to this:

```html
<!DOCYTYPE html>
<html>
  <head>
    <meta charset="UTF-8" />
    <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
    <script type="text/javascript" src="./dist/javascript/jquery.selectpicker.js"></script>
    <link type="text/css" rel="stylesheet" href="./dist/stylesheet/jquery.selectpicker.css"></link>
  </head>
  <body>
    <form id='form1'>
      <select id="select_prefecture_for_form1" name="select_prefecture" data-selectpicker-name='select_prefecture_for_form1'>
        <option value="1">北海道</option>
        <option value="2">青森県</option>
      </select>
    </form>

    <form id='form2'>
      <select id="select_prefecture_for_form2" name="select_prefecture" data-selectpicker-name='select_prefecture_for_form2'>
        <option value="1">北海道</option>
        <option value="2">青森県</option>
      </select>
    </form>

    <script type="text/javascript">
      jQuery( '#select_prefecture_for_form1' ).selectpicker();
      jQuery( '#select_prefecture_for_form2' ).selectpicker();
    </script>
  </body>
</html>
```